### PR TITLE
Renamed menu to Actions; GO logo position

### DIFF
--- a/src/app/layout/components/toolbar/toolbar.component.html
+++ b/src/app/layout/components/toolbar/toolbar.component.html
@@ -17,13 +17,7 @@
   </ng-container>
   <mat-toolbar fxLayout="row" fxLayoutAlign="start center" [ngClass]="{'noc-dev': isDev, 'noc-beta': isBeta }">
     <mat-progress-bar *ngIf="showLoadingBar" class="loading-bar" color="accent" mode="indeterminate"></mat-progress-bar>
-    <div class="h-100-p" fxLayout="row" fxLayoutAlign="start center" fxFlex="200px">
-      <div class="noc-logo pl-8" fxLayout="row" fxLayoutAlign="start">
-        <a href="http://geneontology.org/" target="_blank">
-          <img src="assets/images/logos/go-logo.large.png">
-        </a>
-      </div>
-    </div>
+
     <div class="noc-logo pl-0 h-100-p" fxLayout="row" fxLayoutAlign="start center" fxFlex="180px">
       <ng-container *ngIf="!isBeta && !isDev">
         <a class="noc-main-logo" href="{{noctuaConfigService.noctuaUrl}}" target="_blank">
@@ -92,6 +86,13 @@
             Login
           </a>
         </div>
+      </div>
+    </div>
+    <div class="h-100-p" fxLayout="row" fxLayoutAlign="start center" fxFlex="200px">
+      <div class="noc-logo pl-8" fxLayout="row" fxLayoutAlign="start">
+        <a href="http://geneontology.org/" target="_blank">
+          <img src="assets/images/logos/go-logo.large.png">
+        </a>
       </div>
     </div>
     <div class="noc-bl noc-logo" fxLayout="row" fxLayoutAlign="start">

--- a/src/app/main/apps/noctua-form/cam/copy-model/copy-model.component.html
+++ b/src/app/main/apps/noctua-form/cam/copy-model/copy-model.component.html
@@ -50,22 +50,7 @@
                   </div>
                 </span>
               </div>
-              <div class="noc-item" fxLayout="row" fxLayoutAlign="start center">
-                <div class="noc-title">Open In:</div>
-                <a class="mr-4" [href]='cam.model?.modelInfo?.noctuaVPEUrl' target="_blank">
-                  Pathway Editor
-                </a>
-                <span>&#8226;</span>
-                <a class="ml-4 mr-4" [href]='cam.model?.modelInfo?.noctuaFormUrl' target="_blank">
-                  Form Editor
-                </a>
-                <span>&#8226;</span>
-                <a class="ml-4" [href]='cam.model?.modelInfo?.graphEditorUrl' target="_blank">
-                  Graph Editor
-                </a>
-              </div>
             </div>
-
             <div>
               <mat-checkbox class="example-margin" [(ngModel)]="includeEvidence">Include Evidence</mat-checkbox>
             </div>
@@ -118,11 +103,12 @@
               <div class="noc-item" fxLayout="row" fxLayoutAlign="start center">
                 <div class="noc-title">Open In:</div>
                 <a class="mr-4" [href]='duplicatedCam.model?.modelInfo?.noctuaVPEUrl' target="_blank">
-                  Pathway Editor
+                  Visual Pathway Editor
                 </a>
                 <span>&#8226;</span>
-                <a class="ml-4 mr-4" [href]='duplicatedCam.model?.modelInfo?.noctuaFormUrl' target="_blank">
-                  Form Editor
+                <a class="ml-4 mr-4" [href]="cam?.model?.modelInfo?.workbenches['noctua-standard-annotations']?.url"
+                  target="_blank">
+                  Standard Annotation Editor
                 </a>
                 <span>&#8226;</span>
                 <a class="ml-4" [href]='duplicatedCam.model?.modelInfo?.graphEditorUrl' target="_blank">

--- a/src/app/main/apps/noctua-search/cams/cams-table/cams-table.component.html
+++ b/src/app/main/apps/noctua-search/cams/cams-table/cams-table.component.html
@@ -190,7 +190,7 @@
       <td mat-cell *matCellDef="let cam" fxFlex="120px" fxLayout="row" fxLayoutAlign="start center">
         <a mat-stroked-button [matMenuTriggerFor]="openMenu"
           class="noc-edit-button noc-rounded-button noc-sm noc-half-button" color="primary">
-          Open In
+          Actions
         </a>
         <mat-menu #openMenu="matMenu">
           <ng-container *ngIf="cam.conformsToGpad">
@@ -224,6 +224,12 @@
           <a mat-menu-item [href]="cam?.model?.modelInfo?.workbenches['noctua-alliance-pathway-preview']?.url"
             target="_blank" class="">
             Pathway Viewer
+          </a>
+          <button mat-menu-item (click)="openCopyModel(cam)" class="">
+            Copy Model
+          </button>
+          <a mat-menu-item [href]="cam?.model?.modelInfo?.workbenches['annpreview']?.url" target="_blank" class="">
+            Annotation Preview
           </a>
         </mat-menu>
         <!--    <a mat-icon-button [matMenuTriggerFor]="optionsMenu"

--- a/workbenches/noctua-landing-page/public/inject.tmpl
+++ b/workbenches/noctua-landing-page/public/inject.tmpl
@@ -214,6 +214,6 @@
     </div>
   </noctua-splash-screen>
   <noctua-root></noctua-root>
-<script src="runtime.38b1f495cb4cd82a.js" type="module"></script><script src="polyfills.a39db01cea6f891e.js" type="module"></script><script src="scripts.79b3808e7d5e20c8.js" defer></script><script src="main.396ccd8e3629b454.js" type="module"></script>
+<script src="runtime.38b1f495cb4cd82a.js" type="module"></script><script src="polyfills.a39db01cea6f891e.js" type="module"></script><script src="scripts.79b3808e7d5e20c8.js" defer></script><script src="main.a8643a50c8f2b8f4.js" type="module"></script>
 
 </body></html>

--- a/workbenches/noctua-landing-page/public/inject.tmpl
+++ b/workbenches/noctua-landing-page/public/inject.tmpl
@@ -214,6 +214,6 @@
     </div>
   </noctua-splash-screen>
   <noctua-root></noctua-root>
-<script src="runtime.38b1f495cb4cd82a.js" type="module"></script><script src="polyfills.a39db01cea6f891e.js" type="module"></script><script src="scripts.79b3808e7d5e20c8.js" defer></script><script src="main.bd760814f56c2480.js" type="module"></script>
+<script src="runtime.38b1f495cb4cd82a.js" type="module"></script><script src="polyfills.a39db01cea6f891e.js" type="module"></script><script src="scripts.79b3808e7d5e20c8.js" defer></script><script src="main.396ccd8e3629b454.js" type="module"></script>
 
 </body></html>


### PR DESCRIPTION
### Issues 

- https://github.com/geneontology/noctua-landing-page/issues/124

### Changes

- Now the Open in menu is called Actions
- Added Copy Model and Ann Preview
- GO log now on the right

### Tests

- Please Check if all the link are still opening to correct as it was manual (in case of type)
-
cc @pgaudet @thomaspd @vanaukenk @kltm 